### PR TITLE
update: disable lint on error handler

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,8 +37,9 @@ app.use(express.urlencoded({ extended: true }));
 
 app.use(router);
 
-//* Error Handler with http-errors
-app.use((err, req, res) => {
+//* Error Response Handler
+// eslint-disable-next-line no-unused-vars
+app.use((err, req, res, next) => {
     res.status(err.status || 500);
     res.json({
         status: false,

--- a/middlewares/authentication.js
+++ b/middlewares/authentication.js
@@ -45,10 +45,11 @@ module.exports = async (req, res, next) => {
         next();
     } catch (error) {
         if (error.message === "jwt expired") {
-            res.status(401).json({
-                status: false,
-                message: "Token expired",
-            });
+            return next(
+                createHttpError(401, {
+                    message: "JWT Token Expired",
+                })
+            );
         } else {
             next(
                 createHttpError(500, {


### PR DESCRIPTION
- disable lint for error handler because deleted next parameter will throw error message as html, expected format using JSON